### PR TITLE
set default value for in_lines variable

### DIFF
--- a/bash_snippets.go
+++ b/bash_snippets.go
@@ -10,7 +10,7 @@ const (
 `
 	spyDefinition = `
   # Spy
-  local in_lines
+  local in_lines=""
   while read -r -t0.1; do
     in_lines="${in_lines}${REPLY}
 "


### PR DESCRIPTION
`set -u` fails script when accessing to unassigned variable.
As result in_lines has to have default value to allow using `set -u` in tested scripts